### PR TITLE
Support idempotent (GET) requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ codecs: [ CODEC_JSON ]
 stream_types: [ STREAM_TYPE_UNARY ]
 supports_tls: false
 supports_trailers: false
-supports_connect_get: false
+supports_connect_get: true
 supports_message_receive_limit: false
 ```
 
@@ -87,7 +87,7 @@ Diagnostic data from the server itself is output in the `out/out.log` file.
 
 ### Conformance tests status
 
-Current status: 6/78 tests pass
+Current status: 6/79 tests pass
 
 Known issues:
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val noPublish = List(
 lazy val Versions = new {
   val grpc   = "1.68.1"
   val http4s = "0.23.29"
+  val logback = "1.5.12"
 }
 
 lazy val core = project
@@ -51,6 +52,8 @@ lazy val core = project
       "org.http4s" %% "http4s-client" % Versions.http4s % Test,
 
       "org.scalatest" %% "scalatest" % "3.2.19" % Test,
+
+      "ch.qos.logback" % "logback-classic" % Versions.logback % Test,
     ),
   )
 
@@ -63,7 +66,7 @@ lazy val conformance = project
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-ember-server" % Versions.http4s,
 
-      "ch.qos.logback" % "logback-classic" % "1.5.12" % Runtime,
+      "ch.qos.logback" % "logback-classic" % Versions.logback % Runtime,
     ),
   )
 

--- a/conformance-suite.yaml
+++ b/conformance-suite.yaml
@@ -6,5 +6,5 @@ features:
   stream_types: [ STREAM_TYPE_UNARY ]
   supports_tls: false
   supports_trailers: false
-  supports_connect_get: false
+  supports_connect_get: true
   supports_message_receive_limit: false

--- a/conformance/src/main/scala/org/ivovk/connect_rpc_scala/conformance/Main.scala
+++ b/conformance/src/main/scala/org/ivovk/connect_rpc_scala/conformance/Main.scala
@@ -46,6 +46,7 @@ object Main extends IOApp.Simple {
               p.withTypeRegistry(
                 TypeRegistry.default
                   .addMessage[connectrpc.conformance.v1.UnaryRequest]
+                  .addMessage[connectrpc.conformance.v1.IdempotentUnaryRequest]
                   .addMessage[connectrpc.conformance.v1.ConformancePayload.RequestInfo]
               )
             }

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/MediaTypes.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/MediaTypes.scala
@@ -1,0 +1,17 @@
+package org.ivovk.connect_rpc_scala.http
+
+import org.http4s.MediaType
+
+import scala.annotation.targetName
+
+object MediaTypes {
+
+  @targetName("applicationJson")
+  val `application/json`: MediaType = MediaType.application.json
+
+  @targetName("applicationProto")
+  val `application/proto`: MediaType = MediaType.unsafeParse("application/proto")
+
+  val allSupported: Seq[MediaType] = List(`application/json`, `application/proto`)
+
+}

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/MessageCodec.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/MessageCodec.scala
@@ -36,7 +36,7 @@ class JsonMessageCodec[F[_] : Sync : Compression](jsonPrinter: Printer) extends 
 
   private val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  override val mediaType: MediaType = MediaType.application.`json`
+  override val mediaType: MediaType = MediaTypes.`application/json`
 
   override def decode[A <: Message](m: Media[F])(using cmp: Companion[A]): DecodeResult[F, A] = {
     val charset = m.charset.getOrElse(Charset.`UTF-8`).nioCharset
@@ -72,8 +72,7 @@ class ProtoMessageCodec[F[_] : Async : Compression] extends MessageCodec[F] {
 
   private val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  override val mediaType: MediaType =
-    MediaType.unsafeParse("application/proto")
+  override val mediaType: MediaType = MediaTypes.`application/proto`
 
   override def decode[A <: Message](m: Media[F])(using cmp: Companion[A]): DecodeResult[F, A] = {
     val f = toInputStreamResource(decompressed(m)).use { is =>

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/QueryParams.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/QueryParams.scala
@@ -1,0 +1,23 @@
+package org.ivovk.connect_rpc_scala.http
+
+import org.http4s.dsl.impl.QueryParamDecoderMatcher
+import org.http4s.{Charset, MediaType, ParseFailure, QueryParamDecoder}
+
+import java.net.URLDecoder
+
+object QueryParams {
+
+  private val encodingQPDecoder = QueryParamDecoder[String].emap {
+    case "json" => Right(MediaTypes.`application/json`)
+    case "proto" => Right(MediaTypes.`application/proto`)
+    case other => Left(ParseFailure(other, "Invalid encoding"))
+  }
+
+  object EncodingQP extends QueryParamDecoderMatcher[MediaType]("encoding")(encodingQPDecoder)
+
+  private val messageQPDecoder = QueryParamDecoder[String]
+    .map(URLDecoder.decode(_, Charset.`UTF-8`.nioCharset))
+
+  object MessageQP extends QueryParamDecoderMatcher[String]("message")(messageQPDecoder)
+
+}

--- a/core/src/test/protobuf/TestService.proto
+++ b/core/src/test/protobuf/TestService.proto
@@ -4,6 +4,11 @@ package org.ivovk.connect_rpc_scala.test;
 
 service TestService {
   rpc Add(AddRequest) returns (AddResponse) {}
+
+  // This method can be called using GET request
+  rpc Get(GetRequest) returns (GetResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+  }
 }
 
 message AddRequest {
@@ -13,4 +18,12 @@ message AddRequest {
 
 message AddResponse {
   int32 sum = 1;
+}
+
+message GetRequest {
+  string key = 1;
+}
+
+message GetResponse {
+  string value = 1;
 }

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-4relative %-5level %logger{35} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="org.ivovk.connect_rpc_scala" level="TRACE"/>
+</configuration>

--- a/core/src/test/scala/org/ivovk/connect_rpc_scala/HttpTest.scala
+++ b/core/src/test/scala/org/ivovk/connect_rpc_scala/HttpTest.scala
@@ -9,6 +9,7 @@ import org.http4s.dsl.io.Root
 import org.http4s.headers.`Content-Type`
 import org.http4s.implicits.*
 import org.http4s.{Method, *}
+import org.ivovk.connect_rpc_scala.http.MediaTypes
 import org.ivovk.connect_rpc_scala.test.TestService.TestServiceGrpc.TestService
 import org.ivovk.connect_rpc_scala.test.TestService.{AddRequest, AddResponse, GetRequest, GetResponse}
 import org.scalatest.funsuite.AnyFunSuite
@@ -31,7 +32,7 @@ class HttpTest extends AnyFunSuite, Matchers {
 
   // String-JSON encoder
   given [F[_]]: EntityEncoder[F, String] = EntityEncoder.stringEncoder[F]
-    .withContentType(`Content-Type`(MediaType.application.json))
+    .withContentType(`Content-Type`(MediaTypes.`application/json`))
 
   test("basic") {
     val services: Seq[ServerServiceDefinition] = Seq(
@@ -54,13 +55,13 @@ class HttpTest extends AnyFunSuite, Matchers {
         } yield {
           assert(body == """{"sum":3}""")
           assert(status == Status.Ok)
-          assert(response.headers.get[`Content-Type`].map(_.mediaType).contains(MediaType.application.json))
+          assert(response.headers.get[`Content-Type`].map(_.mediaType).contains(MediaTypes.`application/json`))
         }
       }
       .unsafeRunSync()
   }
 
-  test("GET requests") {
+  test("GET request") {
     val services: Seq[ServerServiceDefinition] = Seq(
       TestService.bindService(TestServiceImpl, ExecutionContext.global)
     )
@@ -76,7 +77,7 @@ class HttpTest extends AnyFunSuite, Matchers {
             Method.GET,
             Uri(
               path = Root / "org.ivovk.connect_rpc_scala.test.TestService" / "Get",
-              query = Query.fromPairs("encoding" -> "json", "value" -> requestJson)
+              query = Query.fromPairs("encoding" -> "json", "message" -> requestJson)
             )
           )
         )
@@ -88,7 +89,7 @@ class HttpTest extends AnyFunSuite, Matchers {
         } yield {
           assert(body == """{"value":"Key is: 123"}""")
           assert(status == Status.Ok)
-          assert(response.headers.get[`Content-Type`].map(_.mediaType).contains(MediaType.application.json))
+          assert(response.headers.get[`Content-Type`].map(_.mediaType).contains(MediaTypes.`application/json`))
         }
       }
       .unsafeRunSync()

--- a/core/src/test/scala/org/ivovk/connect_rpc_scala/HttpTest.scala
+++ b/core/src/test/scala/org/ivovk/connect_rpc_scala/HttpTest.scala
@@ -5,14 +5,16 @@ import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import io.grpc.ServerServiceDefinition
 import org.http4s.client.Client
+import org.http4s.dsl.io.Root
 import org.http4s.headers.`Content-Type`
 import org.http4s.implicits.*
 import org.http4s.{Method, *}
 import org.ivovk.connect_rpc_scala.test.TestService.TestServiceGrpc.TestService
-import org.ivovk.connect_rpc_scala.test.TestService.{AddRequest, AddResponse}
+import org.ivovk.connect_rpc_scala.test.TestService.{AddRequest, AddResponse, GetRequest, GetResponse}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
+import java.net.URLEncoder
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.*
 
@@ -21,12 +23,15 @@ class HttpTest extends AnyFunSuite, Matchers {
   object TestServiceImpl extends TestService {
     override def add(request: AddRequest): Future[AddResponse] =
       Future.successful(AddResponse(request.a + request.b))
+
+    override def get(request: GetRequest): Future[GetResponse] = {
+      Future.successful(GetResponse("Key is: " + request.key))
+    }
   }
 
   // String-JSON encoder
-  given [F[_]]: EntityEncoder[F, String] =
-    EntityEncoder.stringEncoder[F]
-      .withContentType(`Content-Type`(MediaType.application.json))
+  given [F[_]]: EntityEncoder[F, String] = EntityEncoder.stringEncoder[F]
+    .withContentType(`Content-Type`(MediaType.application.json))
 
   test("basic") {
     val services: Seq[ServerServiceDefinition] = Seq(
@@ -48,6 +53,40 @@ class HttpTest extends AnyFunSuite, Matchers {
           status <- response.status.pure[IO]
         } yield {
           assert(body == """{"sum":3}""")
+          assert(status == Status.Ok)
+          assert(response.headers.get[`Content-Type`].map(_.mediaType).contains(MediaType.application.json))
+        }
+      }
+      .unsafeRunSync()
+  }
+
+  test("GET requests") {
+    val services: Seq[ServerServiceDefinition] = Seq(
+      TestService.bindService(TestServiceImpl, ExecutionContext.global)
+    )
+
+    ConnectRpcHttpRoutes.create[IO](services.toList)
+      .flatMap { routes =>
+        val client = Client.fromHttpApp(routes.orNotFound)
+
+        val requestJson = URLEncoder.encode("""{"key":"123"}""", Charset.`UTF-8`.nioCharset)
+
+        client.run(
+          Request[IO](
+            Method.GET,
+            Uri(
+              path = Root / "org.ivovk.connect_rpc_scala.test.TestService" / "Get",
+              query = Query.fromPairs("encoding" -> "json", "value" -> requestJson)
+            )
+          )
+        )
+      }
+      .use { response =>
+        for {
+          body <- response.as[String]
+          status <- response.status.pure[IO]
+        } yield {
+          assert(body == """{"value":"Key is: 123"}""")
           assert(status == Status.Ok)
           assert(response.headers.get[`Content-Type`].map(_.mediaType).contains(MediaType.application.json))
         }


### PR DESCRIPTION
Related to #10. Blocked by ScalaPB not setting `safe` option in the MethodDescriptor (https://github.com/scalapb/ScalaPB/pull/1774).