### PR TITLE
Support external configuration for GRPC client and server builders

### DIFF
--- a/conformance/src/main/scala/org/ivovk/connect_rpc_scala/conformance/Main.scala
+++ b/conformance/src/main/scala/org/ivovk/connect_rpc_scala/conformance/Main.scala
@@ -40,7 +40,7 @@ object Main extends IOApp.Simple {
         .create[IO](
           Seq(service),
           Configuration(
-            jsonPrinterConfiguration = { p =>
+            jsonPrinterConfigurer = { p =>
               // Registering message types in TypeRegistry is required to pass com.google.protobuf.any.Any
               // JSON-serialization conformance tests
               p.withTypeRegistry(

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/InProcessChannelBridge.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/InProcessChannelBridge.scala
@@ -1,24 +1,28 @@
 package org.ivovk.connect_rpc_scala
 
+import cats.Endo
 import cats.effect.{Resource, Sync}
 import cats.implicits.*
+import io.grpc.*
 import io.grpc.inprocess.{InProcessChannelBuilder, InProcessServerBuilder}
-import io.grpc.{Channel, ManagedChannel, Server, ServerServiceDefinition}
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters.*
+import scala.util.chaining.*
 
 object InProcessChannelBridge {
 
   def create[F[_] : Sync](
     services: Seq[ServerServiceDefinition],
+    serverBuilderConfigurer: Endo[ServerBuilder[?]] = identity,
+    channelBuilderConfigurer: Endo[ManagedChannelBuilder[?]] = identity,
     waitForShutdown: Duration,
   ): Resource[F, Channel] = {
     for
       name <- Resource.eval(Sync[F].delay(InProcessServerBuilder.generateName()))
-      server <- createServer(name, services, waitForShutdown)
-      channel <- createStub(name, waitForShutdown)
+      server <- createServer(name, services, waitForShutdown, serverBuilderConfigurer)
+      channel <- createStub(name, waitForShutdown, channelBuilderConfigurer)
     yield channel
   }
 
@@ -26,11 +30,13 @@ object InProcessChannelBridge {
     name: String,
     services: Seq[ServerServiceDefinition],
     waitForShutdown: Duration,
+    serverBuilderConfigurer: Endo[ServerBuilder[?]] = identity,
   ): Resource[F, Server] = {
     val acquire = Sync[F].delay {
       InProcessServerBuilder.forName(name)
         .directExecutor()
         .addServices(services.asJava)
+        .pipe(serverBuilderConfigurer)
         .build()
         .start()
     }
@@ -43,10 +49,12 @@ object InProcessChannelBridge {
   private def createStub[F[_] : Sync](
     name: String,
     waitForShutdown: Duration,
+    channelBuilderConfigurer: Endo[ManagedChannelBuilder[?]] = identity,
   ): Resource[F, ManagedChannel] = {
     val acquire = Sync[F].delay {
       InProcessChannelBuilder.forName(name)
         .directExecutor()
+        .pipe(channelBuilderConfigurer)
         .build()
     }
     val release = (c: ManagedChannel) =>


### PR DESCRIPTION
To be able to register them in Otel metrics. May be helpful for other things.