### PR TITLE
Initial preparations to support GRPC Transcoding

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,6 +54,9 @@ lazy val core = project
       "io.grpc" % "grpc-protobuf" % Versions.grpc,
       "io.grpc" % "grpc-inprocess" % Versions.grpc,
 
+      "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.11" % "2.9.6-0" % "protobuf",
+      "com.thesamet.scalapb.common-protos" %% "proto-google-common-protos-scalapb_0.11" % "2.9.6-0",
+
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
 
       "org.http4s" %% "http4s-dsl" % Versions.http4s,

--- a/conformance/src/main/resources/logback.xml
+++ b/conformance/src/main/resources/logback.xml
@@ -3,14 +3,6 @@
 
 <configuration>
 
-    <!--    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">-->
-    <!--        <encoder>-->
-    <!--            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>-->
-    <!--        </encoder>-->
-    <!--    </appender>-->
-
-    <!--    <appender name="NOOP" class="ch.qos.logback.core.helpers.NOPAppender"/>-->
-
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>${LOGS_PATH}/out.log</file>
         <append>true</append>

--- a/core/src/main/protobuf/connectrpc/package.proto
+++ b/core/src/main/protobuf/connectrpc/package.proto
@@ -11,4 +11,5 @@ option (scalapb.options) = {
   enum_value_naming: CAMEL_CASE
   enum_strip_prefix: true
   preserve_unknown_fields: false
+  scala3_sources: true
 };

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/grpc/MethodName.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/grpc/MethodName.scala
@@ -6,7 +6,7 @@ type Service = String
 type Method = String
 
 object MethodName {
-  def apply(descriptor: MethodDescriptor[_, _]): MethodName =
+  def from(descriptor: MethodDescriptor[_, _]): MethodName =
     MethodName(descriptor.getServiceName, descriptor.getBareMethodName)
 }
 

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/grpc/MethodRegistry.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/grpc/MethodRegistry.scala
@@ -1,6 +1,9 @@
 package org.ivovk.connect_rpc_scala.grpc
 
+import com.google.api.AnnotationsProto
+import com.google.api.http.HttpRule
 import io.grpc.{MethodDescriptor, ServerMethodDefinition, ServerServiceDefinition}
+import scalapb.grpc.ConcreteProtoMethodDescriptorSupplier
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import scala.jdk.CollectionConverters.*
@@ -8,7 +11,9 @@ import scala.jdk.CollectionConverters.*
 object MethodRegistry {
 
   case class Entry(
+    name: MethodName,
     requestMessageCompanion: GeneratedMessageCompanion[GeneratedMessage],
+    httpRule: Option[HttpRule],
     descriptor: MethodDescriptor[GeneratedMessage, GeneratedMessage],
   )
 
@@ -30,23 +35,37 @@ object MethodRegistry {
         val requestCompanion = companionField.get(requestMarshaller)
           .asInstanceOf[GeneratedMessageCompanion[GeneratedMessage]]
 
-        val methodEntry = Entry(
+        val httpRule = extractHttpRule(methodDescriptor)
+
+        Entry(
+          name = MethodName.from(methodDescriptor),
           requestMessageCompanion = requestCompanion,
+          httpRule = httpRule,
           descriptor = methodDescriptor,
         )
-
-        MethodName(methodDescriptor) -> methodEntry
       }
-      .groupMapReduce((mn, _) => mn.service)((mn, m) => Map(mn.method -> m))(_ ++ _)
+      .groupMapReduce(_.name.service)(e => Map(e.name.method -> e))(_ ++ _)
 
     new MethodRegistry(entries)
+  }
+
+  private def extractHttpRule(methodDescriptor: MethodDescriptor[_, _]): Option[HttpRule] = {
+    methodDescriptor.getSchemaDescriptor match
+      case sd: ConcreteProtoMethodDescriptorSupplier =>
+        val fields      = sd.getMethodDescriptor.getOptions.getUnknownFields
+        val fieldNumber = AnnotationsProto.http.getNumber
+
+        if fields.hasField(fieldNumber) then
+          Some(HttpRule.parseFrom(fields.getField(fieldNumber).getLengthDelimitedList.get(0).toByteArray))
+        else None
+      case _ => None
   }
 
 }
 
 class MethodRegistry private(entries: Map[Service, Map[Method, MethodRegistry.Entry]]) {
 
-  def get(methodName: MethodName): Option[MethodRegistry.Entry] =
-    entries.getOrElse(methodName.service, Map.empty).get(methodName.method)
+  def get(service: Service, method: Method): Option[MethodRegistry.Entry] =
+    entries.getOrElse(service, Map.empty).get(method)
 
 }

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/RequestEntity.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/RequestEntity.scala
@@ -3,15 +3,11 @@ package org.ivovk.connect_rpc_scala.http
 import cats.MonadThrow
 import fs2.Stream
 import org.http4s.headers.{`Content-Encoding`, `Content-Type`}
-import org.http4s.{Charset, ContentCoding, Headers, Media}
+import org.http4s.{Charset, ContentCoding, Headers}
 import org.ivovk.connect_rpc_scala.http.Headers.`Connect-Timeout-Ms`
 import org.ivovk.connect_rpc_scala.http.codec.MessageCodec
 import scalapb.{GeneratedMessage as Message, GeneratedMessageCompanion as Companion}
 
-object RequestEntity {
-  def apply[F[_]](m: Media[F]): RequestEntity[F] =
-    RequestEntity(m.body, m.headers)
-}
 
 /**
  * Encoded message and headers with the knowledge how this message can be decoded.
@@ -23,7 +19,7 @@ case class RequestEntity[F[_]](
   headers: Headers,
 ) {
 
-  def contentType: Option[`Content-Type`] =
+  private def contentType: Option[`Content-Type`] =
     headers.get[`Content-Type`]
 
   def charset: Charset =

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/codec/MessageCodec.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/codec/MessageCodec.scala
@@ -1,15 +1,11 @@
 package org.ivovk.connect_rpc_scala.http.codec
 
-import cats.Applicative
 import org.http4s.headers.`Content-Type`
-import org.http4s.{DecodeResult, Entity, EntityDecoder, EntityEncoder, MediaRange, MediaType}
+import org.http4s.{DecodeResult, Entity, EntityEncoder, MediaType}
 import org.ivovk.connect_rpc_scala.http.RequestEntity
 import scalapb.{GeneratedMessage as Message, GeneratedMessageCompanion as Companion}
 
 object MessageCodec {
-  given [F[_] : Applicative, A <: Message](using codec: MessageCodec[F], cmp: Companion[A]): EntityDecoder[F, A] =
-    EntityDecoder.decodeBy(MediaRange.`*/*`)(m => codec.decode(RequestEntity(m)))
-
   given [F[_], A <: Message](using codec: MessageCodec[F]): EntityEncoder[F, A] =
     EntityEncoder.encodeBy(`Content-Type`(codec.mediaType))(codec.encode)
 }

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/codec/MessageCodecRegistry.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/codec/MessageCodecRegistry.scala
@@ -11,6 +11,6 @@ object MessageCodecRegistry {
 
 class MessageCodecRegistry[F[_]] private(encoders: Map[MediaType, MessageCodec[F]]) {
 
-  def byContentType(mediaType: MediaType): Option[MessageCodec[F]] = encoders.get(mediaType)
+  def byMediaType(mediaType: MediaType): Option[MessageCodec[F]] = encoders.get(mediaType)
 
 }

--- a/core/src/test/protobuf/test/ConnectCommunicationTest.proto
+++ b/core/src/test/protobuf/test/ConnectCommunicationTest.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package org.ivovk.connect_rpc_scala.test;
+package test;
 
 service TestService {
   rpc Add(AddRequest) returns (AddResponse) {}

--- a/core/src/test/protobuf/test/MethodRegistryTest.proto
+++ b/core/src/test/protobuf/test/MethodRegistryTest.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package test;
+
+import "google/api/annotations.proto";
+
+service MethodRegistryTestService {
+  rpc SimpleMethod(SimpleMethodRequest) returns (SimpleMethodResponse) {}
+
+  rpc HttpAnnotationMethod(HttpAnnotationMethodRequest) returns (HttpAnnotationMethodResponse) {
+    option (google.api.http) = {
+      post: "/v1/test/http_annotation_method"
+      body: "*"
+    };
+  }
+}
+
+message SimpleMethodRequest {}
+
+message SimpleMethodResponse {}
+
+message HttpAnnotationMethodRequest {}
+
+message HttpAnnotationMethodResponse {}

--- a/core/src/test/protobuf/test/package.proto
+++ b/core/src/test/protobuf/test/package.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 
-package connectrpc;
+package test;
 
 import "scalapb/scalapb.proto";
 
 option (scalapb.options) = {
   scope: PACKAGE
-  flat_package: true
+  flat_package: false
   lenses: false
   enum_value_naming: CAMEL_CASE
   enum_strip_prefix: true

--- a/core/src/test/resources/logback.xml
+++ b/core/src/test/resources/logback.xml
@@ -5,7 +5,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%-4relative %-5level %logger{35} -%kvp- %msg%n</pattern>
+            <pattern>%-4relative %-5level %logger{5} -%kvp- %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/core/src/test/scala/org/ivovk/connect_rpc_scala/http/grpc/MethodRegistryTest.scala
+++ b/core/src/test/scala/org/ivovk/connect_rpc_scala/http/grpc/MethodRegistryTest.scala
@@ -1,0 +1,42 @@
+package org.ivovk.connect_rpc_scala.http.grpc
+
+import org.ivovk.connect_rpc_scala.grpc.MethodRegistry
+import org.scalatest.funsuite.AnyFunSuite
+import test.MethodRegistryTest.*
+import test.MethodRegistryTest.MethodRegistryTestServiceGrpc.MethodRegistryTestService
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class MethodRegistryTest extends AnyFunSuite {
+
+  object TestService extends MethodRegistryTestService {
+    override def simpleMethod(request: SimpleMethodRequest): Future[SimpleMethodResponse] = ???
+
+    override def httpAnnotationMethod(request: HttpAnnotationMethodRequest): Future[HttpAnnotationMethodResponse] = ???
+  }
+
+  test("support simple methods") {
+    val service  = MethodRegistryTestService.bindService(TestService, ExecutionContext.global)
+    val registry = MethodRegistry(Seq(service))
+
+    val entry = registry.get("test.MethodRegistryTestService", "SimpleMethod")
+    assert(entry.isDefined)
+    assert(entry.get.name.service == "test.MethodRegistryTestService")
+    assert(entry.get.name.method == "SimpleMethod")
+  }
+
+  test("parse http annotations") {
+    val service  = MethodRegistryTestService.bindService(TestService, ExecutionContext.global)
+    val registry = MethodRegistry(Seq(service))
+
+    val entry = registry.get("test.MethodRegistryTestService", "HttpAnnotationMethod")
+    assert(entry.isDefined)
+    assert(entry.get.httpRule.isDefined)
+
+    val httpRule = entry.get.httpRule.get
+
+    assert(httpRule.getPost == "/v1/test/http_annotation_method")
+    assert(httpRule.body == "*")
+  }
+
+}


### PR DESCRIPTION
refs #51 

 - extract `google.api.http` annotation when it's present
 - support other routes instead of returning 404 when method doesn't match