### PR TITLE
Rename user-agent header to x-user-agent, since original one gets overridden (more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ httpServer.use(_ => IO.never).unsafeRunSync()
 
 ### Hint: GRPC OpenTelemetry integration
 
-Since the library creates a separate "fake" GRPC server, traffic going through it won't be captured by the
-instrumentation of your main GRPC server (if any).
+Since the library creates a separate in-process GRPC server, traffic going through it won't be captured by the
+instrumentation of your main GRPC server (if there is any).
 
 Here is how you can integrate OpenTelemetry with the Connect-RPC server:
 
@@ -267,6 +267,14 @@ Consider that normally you would use this library only once, where request lands
 communicate with the internal services using GRPC.
 And it should be compared with using a separate proxy (Envoy or GRPC Gateway) for the same purpose, which is one more
 hop, and needs protobuf files.
+
+#### Header Modifications
+
+* All incoming `Connection-*` headers are removed, as they aren’t allowed by GRPC.
+* All outgoing `grpc-*` headers are removed.
+* Original `User-Agent` request header is renamed to `x-user-agent`,
+  `user-agent` is set to the in-process client's User Agent (`grpc-java-inprocess/1.69.0`),
+  there is no way to disable it.
 
 ### Thanks
 

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/ConnectRouteBuilder.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/ConnectRouteBuilder.scala
@@ -181,7 +181,7 @@ final class ConnectRouteBuilder[F[_] : Async] private(
         headerMapping,
       )
 
-      val connectHandler = ConnectHandler(
+      val connectHandler = ConnectHandler[F](
         channel,
         connectErrorHandler,
         headerMapping,
@@ -199,13 +199,13 @@ final class ConnectRouteBuilder[F[_] : Async] private(
         pathPrefix,
       )
 
-      val transcodingHandler = TranscodingHandler(
+      val transcodingHandler = TranscodingHandler[F](
         channel,
         transcodingErrorHandler.getOrElse(connectErrorHandler),
         headerMapping,
       )
 
-      val transcodingRoutes = TranscodingRoutesProvider(
+      val transcodingRoutes = TranscodingRoutesProvider[F](
         transcodingUrlMatcher,
         transcodingHandler,
         jsonSerDeser

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/Mappings.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/Mappings.scala
@@ -2,6 +2,7 @@ package org.ivovk.connect_rpc_scala
 
 import io.grpc.{Metadata, Status}
 import org.http4s.{Header, Headers, Response}
+import org.ivovk.connect_rpc_scala.grpc.GrpcHeaders
 import org.ivovk.connect_rpc_scala.grpc.GrpcHeaders.asciiKey
 import org.ivovk.connect_rpc_scala.http.codec.{EncodeOptions, MessageCodec}
 import org.typelevel.ci.CIString
@@ -18,11 +19,20 @@ class HeaderMapping(
     headers.headers.foreach { header =>
       val headerName = header.name.toString
       if (headersFilter(headerName)) {
-        metadata.put(asciiKey(headerName), header.value)
+        metadata.put(metadataKeyByHeaderName(headerName), header.value)
       }
     }
     metadata
   }
+
+  private def metadataKeyByHeaderName(headerName: String): Metadata.Key[String] =
+    headerName match {
+      case "User-Agent" | "user-agent" =>
+        // Rename `User-Agent` to `x-user-agent` because `user-agent` is overridden by gRPC
+        GrpcHeaders.XUserAgentKey
+      case _ =>
+        asciiKey(headerName)
+    }
 
   private def headers(
     metadata: Metadata,

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/grpc/GrpcHeaders.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/grpc/GrpcHeaders.scala
@@ -12,6 +12,8 @@ object GrpcHeaders {
       override def parseBytes(serialized: Array[Byte]): ErrorDetailsAny = ErrorDetailsAny.parseFrom(serialized)
     })
 
+  val XUserAgentKey: Metadata.Key[String] = asciiKey("x-user-agent")
+
   inline def asciiKey(name: String): Metadata.Key[String] =
     Metadata.Key.of(name, Metadata.ASCII_STRING_MARSHALLER)
 


### PR DESCRIPTION
Use existing code for parsing grpc-timeout header