### PR TITLE
Fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -36,6 +36,7 @@ jobs:
 
     strategy:
       matrix:
+        config:
           - name: Netty Server
             args: --build-arg launcher=NettyServerLauncher --build-arg config=suite-netty.yaml
           - name: Http4s Server

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -31,10 +31,11 @@ jobs:
 
   conformance:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:
-        config:
           - name: Netty Server
             args: --build-arg launcher=NettyServerLauncher --build-arg config=suite-netty.yaml
           - name: Http4s Server


### PR DESCRIPTION
Potential fix for [https://github.com/igor-vovk/connect-rpc-scala/security/code-scanning/4](https://github.com/igor-vovk/connect-rpc-scala/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the `conformance` job. Since the job only checks out the repository and runs Docker commands, it does not require any write permissions. The minimal permissions required are `contents: read`. This change ensures that the `GITHUB_TOKEN` has the least privilege necessary to execute the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
