### PR TITLE
Update dependencies and release tooling

### DIFF
--- a/.github/actions/setup-scala/action.yml
+++ b/.github/actions/setup-scala/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
-        java-version: '24'
+        java-version: '25'
         distribution: 'temurin'
         cache: 'sbt'
     

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
+
+  - package-ecosystem: "sbt"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+
+  - package-ecosystem: "docker"
+    directory: "/conformance-build"
+    schedule:
+      interval: "weekly"
+      day: "friday"

--- a/build.sbt
+++ b/build.sbt
@@ -29,14 +29,14 @@ lazy val noPublish = List(
 
 lazy val Versions = new {
   val cedi      = "0.2.3"
-  val fs2       = "3.12.2"
-  val grpc      = "1.78.0"
-  val http4s    = "0.23.33"
-  val logback   = "1.5.24"
+  val fs2       = "3.13.0"
+  val grpc      = "1.83.0"
+  val http4s    = "0.23.36"
+  val logback   = "1.6.1"
   val netty     = "4.2.9.Final"
   val scalapb   = _root_.scalapb.compiler.Version.scalapbVersion
-  val slf4j     = "2.0.17"
-  val scalatest = "3.2.19"
+  val slf4j     = "2.0.18"
+  val scalatest = "3.2.20"
 }
 
 lazy val commonDeps = Seq(
@@ -156,7 +156,7 @@ lazy val example_zio_client_server = project.in(file("examples/zio_client_server
     libraryDependencies ++= Seq(
       "org.http4s"    %% "http4s-ember-server" % Versions.http4s,
       "org.http4s"    %% "http4s-ember-client" % Versions.http4s,
-      "dev.zio"       %% "zio"                 % "2.1.24",
+      "dev.zio"       %% "zio"                 % "2.1.26",
       "dev.zio"       %% "zio-interop-cats"    % "23.1.0.13",
       "ch.qos.logback" % "logback-classic"     % Versions.logback % Runtime,
     ),

--- a/conformance-build/Dockerfile
+++ b/conformance-build/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:24-jre AS base
+FROM docker.io/library/eclipse-temurin:25-jre AS base
 
 FROM ghcr.io/igor-vovk/connect-conformance-dockerimage:1.0.5-1 AS conformance
 
@@ -28,4 +28,4 @@ RUN LOGS_PATH="/out" \
 
 FROM scratch AS export
 
-COPY --link --from=runner /out /
+COPY --from=runner /out /

--- a/conformance/src/main/scala/org/ivovk/connect_rpc_scala/conformance/Http4sServerLauncher.scala
+++ b/conformance/src/main/scala/org/ivovk/connect_rpc_scala/conformance/Http4sServerLauncher.scala
@@ -32,7 +32,7 @@ object Http4sServerLauncher extends IOApp.Simple {
 
   override def run: IO[Unit] = {
     val res = for
-      req <- stdin[IO](2048)
+      _ <- stdin[IO](2048)
         .through(StreamDecoder.once(ProtoCodecs.decoderFor[conformance.ServerCompatRequest]).toPipeByte)
         .compile.onlyOrError.toResource
 

--- a/conformance/src/main/scala/org/ivovk/connect_rpc_scala/conformance/NettyServerLauncher.scala
+++ b/conformance/src/main/scala/org/ivovk/connect_rpc_scala/conformance/NettyServerLauncher.scala
@@ -29,7 +29,7 @@ object NettyServerLauncher extends IOApp.Simple {
 
   override def run: IO[Unit] = {
     val res = for
-      req <- stdin[IO](2048)
+      _ <- stdin[IO](2048)
         .through(StreamDecoder.once(ProtoCodecs.decoderFor[conformance.ServerCompatRequest]).toPipeByte)
         .compile.onlyOrError.toResource
 

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/grpc/InProcessChannelBridge.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/grpc/InProcessChannelBridge.scala
@@ -24,7 +24,7 @@ object InProcessChannelBridge {
   ): Resource[F, Channel] =
     for
       name    <- Resource.eval(Sync[F].delay(InProcessServerBuilder.generateName()))
-      server  <- createServer(name, services, serverConfigurator, executor, waitForShutdown)
+      _       <- createServer(name, services, serverConfigurator, executor, waitForShutdown)
       channel <- createStub(name, channelConfigurator, executor, waitForShutdown)
     yield channel
 

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/json/ConnectErrorFormat.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/json/ConnectErrorFormat.scala
@@ -29,7 +29,7 @@ object ConnectErrorFormat {
   }
 
   val parser: Reader[Error] = {
-    case (parser, obj @ JObject(fields)) =>
+    case (parser, obj @ JObject(_)) =>
       val code = obj \ "code" match
         case JString(code) =>
           connectrpc.Code

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/json/EndStreamMessageFormat.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/json/EndStreamMessageFormat.scala
@@ -17,7 +17,7 @@ object EndStreamMessageFormat {
   }
 
   val parser: Reader[EndStreamMessage] = {
-    case (parser, obj @ JObject(fields)) =>
+    case (parser, obj @ JObject(_)) =>
       val error = obj \ "error" match
         case JNothing  => None
         case errorJson => Some(ConnectErrorFormat.parser(parser, errorJson))

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/json/ErrorDetailsAnyFormat.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/json/ErrorDetailsAnyFormat.scala
@@ -22,14 +22,14 @@ object ErrorDetailsAnyFormat {
   }
 
   val parser: Reader[ErrorDetailsAny] = {
-    case (parser, obj @ JObject(fields)) =>
+    case (_, obj @ JObject(_)) =>
       (obj \ "type", obj \ "value") match {
         case (JString(t), JString(v)) =>
           ErrorDetailsAny(t, unsafeWrap(base64dec.decode(v)))
         case _ =>
           throw new JsonFormatException(s"Error parsing ErrorDetailAny: $obj")
       }
-    case (parser, other) =>
+    case (_, other) =>
       throw new JsonFormatException(s"Expected an object, got $other")
   }
 

--- a/core/src/main/scala/org/ivovk/connect_rpc_scala/http/json/JsonProcessing.scala
+++ b/core/src/main/scala/org/ivovk/connect_rpc_scala/http/json/JsonProcessing.scala
@@ -42,8 +42,8 @@ object JsonProcessing {
       .mapValues { fields =>
         if (
           fields.forall {
-            case (list: List[String], v: JValue) => true
-            case _                               => false
+            case (_: List[String], _: JValue) => true
+            case _                            => false
           }
         ) {
           JObject(groupFields2(fields.asInstanceOf[List[(List[String], JValue)]]))

--- a/http4s/src/test/scala/org/ivovk/connect_rpc_scala/http4s/HttpCommunicationTest.scala
+++ b/http4s/src/test/scala/org/ivovk/connect_rpc_scala/http4s/HttpCommunicationTest.scala
@@ -164,7 +164,7 @@ class HttpCommunicationTest extends AnyFunSuite, Matchers {
       }
       .use { response =>
         for {
-          body <- response.as[String]
+          _ <- response.as[String]
         } yield assert(response.status == Status.NotFound)
       }
       .unsafeRunSync()

--- a/netty/src/main/scala/org/ivovk/connect_rpc_scala/netty/HttpServerHandler.scala
+++ b/netty/src/main/scala/org/ivovk/connect_rpc_scala/netty/HttpServerHandler.scala
@@ -128,6 +128,8 @@ class HttpServerHandler[F[_]: Async](
                 Async[F].delay(ctx.fireChannelReadComplete())
             }
         }
+      case other =>
+        super.channelRead(ctx, other)
     }
 
   private def sendError(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.11.7
+sbt.version = 1.12.14

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
-addSbtPlugin("org.typelevel"  % "sbt-tpolecat"        % "0.5.2")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"      % "1.11.2")
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")
+addSbtPlugin("org.typelevel"  % "sbt-tpolecat"        % "0.5.7")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"      % "1.12.0")
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")
 addSbtPlugin("com.thesamet"   % "sbt-protoc"          % "1.0.8")
-addSbtPlugin("org.typelevel"  % "sbt-fs2-grpc"        % "2.11.0")
-addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.5.6")
+addSbtPlugin("org.typelevel"  % "sbt-fs2-grpc"        % "3.1.2")
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.6.2")
 
 libraryDependencies += "com.thesamet.scalapb"          %% "compilerplugin"   % "0.11.20"
 libraryDependencies += "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.3"


### PR DESCRIPTION
## Summary

- update the core library and test dependencies, including fs2, gRPC, http4s, Logback, SLF4J, ScalaTest, and ZIO
- update sbt to 1.12.14 and refresh sbt plugins, including tpolecat, ci-release, native-packager, fs2-grpc, and scalafmt
- move CI and conformance execution to the Java 25 LTS runtime
- enable weekly Dependabot updates for sbt and Docker in addition to GitHub Actions
- make the conformance Dockerfile work with both Docker and Podman
- resolve stricter compiler warnings enabled by the upgraded tpolecat plugin and safely forward unexpected Netty messages

## Why

The last release was nine months ago, while scheduled Dependabot updates covered only GitHub Actions. The dependency and release toolchain had therefore drifted, and newer plugins exposed build compatibility and strict-warning issues. This refresh prepares the project for a new release and ensures future sbt and container updates are monitored automatically.

## Impact

Published modules keep their existing APIs while building and testing against current dependency versions. CI and conformance testing now use Java 25 LTS. The source changes are limited to unused-binding cleanup plus forwarding non-HTTP Netty messages to the next handler.

## Validation

- `sbt scalafmtCheckAll test` — 31 tests passed
- `sbt scalafmtSbtCheck`
- `make test-conformance-stable`
  - HTTP4s server: 198 passed
  - HTTP4s client: 39 passed
  - Netty server: 81 passed
  - total: 318 passed, 0 failed
- `sbt evicted`
- `git diff --check`
