### PR TITLE
Remove deprecated builder aliases

### DIFF
--- a/http4s/src/main/scala/org/ivovk/connect_rpc_scala/http4s/ConnectHttp4sRouteBuilder.scala
+++ b/http4s/src/main/scala/org/ivovk/connect_rpc_scala/http4s/ConnectHttp4sRouteBuilder.scala
@@ -22,39 +22,6 @@ import java.util.concurrent.Executor
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.*
 
-@deprecated("Use ConnectHttp4sRouteBuilder", "0.4.1")
-object Http4sRouteBuilder {
-
-  /** Please use [[ConnectHttp4sRouteBuilder.forService]] instead. */
-  def forService[F[_]: Async](service: ServerServiceDefinition): ConnectHttp4sRouteBuilder[F] =
-    forServices(Seq(service))
-
-  /** Please use [[ConnectHttp4sRouteBuilder.forServices]] instead. */
-  def forServices[F[_]: Async](
-    service: ServerServiceDefinition,
-    other: ServerServiceDefinition*
-  ): ConnectHttp4sRouteBuilder[F] =
-    forServices(service +: other)
-
-  /** Please use [[ConnectHttp4sRouteBuilder.forServices]] instead. */
-  def forServices[F[_]: Async](services: Seq[ServerServiceDefinition]): ConnectHttp4sRouteBuilder[F] =
-    new ConnectHttp4sRouteBuilder(
-      services = services,
-      serverConfigurator = identity,
-      channelConfigurator = identity,
-      customJsonSerdes = None,
-      incomingHeadersFilter = HeaderMapping.DefaultIncomingHeadersFilter,
-      outgoingHeadersFilter = HeaderMapping.DefaultOutgoingHeadersFilter,
-      pathPrefix = Uri.Path.Root,
-      executor = ExecutionContext.global,
-      waitForShutdown = 5.seconds,
-      treatTrailersAsHeaders = true,
-      transcodingErrorHandler = None,
-      additionalRoutes = None,
-    )
-
-}
-
 object ConnectHttp4sRouteBuilder {
 
   def forService[F[_]: Async](service: ServerServiceDefinition): ConnectHttp4sRouteBuilder[F] =

--- a/netty/src/main/scala/org/ivovk/connect_rpc_scala/netty/ConnectNettyServerBuilder.scala
+++ b/netty/src/main/scala/org/ivovk/connect_rpc_scala/netty/ConnectNettyServerBuilder.scala
@@ -39,35 +39,6 @@ case class Server(
   def port: Int    = address.getPort
 }
 
-@deprecated("Use ConnectNettyServerBuilder", "0.4.1")
-object NettyServerBuilder {
-
-  /** Please use [[ConnectNettyServerBuilder.forService]] instead. */
-  def forService[F[_]: Async: Parallel](service: ServerServiceDefinition): ConnectNettyServerBuilder[F] =
-    forServices(Seq(service))
-
-    /** Please use [[ConnectNettyServerBuilder.forServices]] instead. */
-  def forServices[F[_]: Async: Parallel](
-    services: Seq[ServerServiceDefinition]
-  ): ConnectNettyServerBuilder[F] =
-    new ConnectNettyServerBuilder[F](
-      services = services,
-      serverConfigurator = identity,
-      enableLogging = false,
-      channelConfigurator = identity,
-      customJsonSerdes = None,
-      incomingHeadersFilter = HeaderMapping.DefaultIncomingHeadersFilter,
-      outgoingHeadersFilter = HeaderMapping.DefaultOutgoingHeadersFilter,
-      pathPrefix = Uri.Path.Root,
-      executor = ExecutionContext.global,
-      waitForShutdown = 5.seconds,
-      treatTrailersAsHeaders = true,
-      host = "0.0.0.0",
-      port = 0,
-    )
-
-}
-
 object ConnectNettyServerBuilder {
 
   def forService[F[_]: Async: Parallel](service: ServerServiceDefinition): ConnectNettyServerBuilder[F] =


### PR DESCRIPTION
## Summary

- remove the deprecated `Http4sRouteBuilder` compatibility object
- remove the deprecated `NettyServerBuilder` compatibility object
- retain the replacement APIs: `ConnectHttp4sRouteBuilder` and `ConnectNettyServerBuilder`

## Why

These aliases have been deprecated since 0.4.1. Removing them after the 0.5.0 release trims duplicate public API before the next release.

## Compatibility

This is a source-breaking change for callers still using the deprecated aliases. Migration is a direct rename:

- `Http4sRouteBuilder` → `ConnectHttp4sRouteBuilder`
- `NettyServerBuilder` → `ConnectNettyServerBuilder`

As a pre-1.0 breaking change, this should ship in 0.6.0 rather than a 0.5.x patch.

## Validation

- `sbt scalafmtCheckAll scalafmtSbtCheck test` — 31 tests passed
- `make test-conformance-stable` — 318 cases passed (198 HTTP4s server, 39 HTTP4s client, 81 Netty server)
- confirmed there are no internal references to the removed aliases
