### PR TITLE
Add JSON codec performance benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,19 @@
+# Benchmarks
+
+The benchmarks use [JMH](https://github.com/openjdk/jmh) to measure performance-sensitive paths through the public
+library implementation.
+
+Run the full benchmark configuration:
+
+```shell
+sbt "benchmarks/Jmh/run"
+```
+
+For a quicker local comparison:
+
+```shell
+sbt "benchmarks/Jmh/run -wi 3 -i 5 -f 1 -t 1"
+```
+
+Run comparisons on the same machine and JVM while other system load is low. Compare commits using identical JMH
+arguments; absolute timings from different environments are not directly comparable.

--- a/benchmarks/src/main/scala/org/ivovk/connect_rpc_scala/benchmark/JsonMessageCodecBenchmark.scala
+++ b/benchmarks/src/main/scala/org/ivovk/connect_rpc_scala/benchmark/JsonMessageCodecBenchmark.scala
@@ -1,0 +1,83 @@
+package org.ivovk.connect_rpc_scala.benchmark
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import com.google.protobuf.ByteString
+import connectrpc.{Code, Error, ErrorDetailsAny}
+import fs2.Stream
+import io.grpc.Metadata
+import org.http4s.ContentCoding
+import org.ivovk.connect_rpc_scala.http.codec.{
+  EncodeOptions,
+  EntityToDecode,
+  JsonMessageCodec,
+  JsonSerdesBuilder,
+}
+import org.openjdk.jmh.annotations.{
+  Benchmark,
+  BenchmarkMode,
+  Fork,
+  Measurement,
+  Mode,
+  OutputTimeUnit,
+  Param,
+  Scope,
+  Setup,
+  State,
+  Warmup,
+}
+
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+@State(Scope.Benchmark)
+class JsonMessageCodecBenchmark {
+
+  @Param(Array("1", "10", "100"))
+  var detailsCount: Int = 0
+
+  private given runtime: IORuntime = IORuntime.global
+
+  private var codec: JsonMessageCodec[IO] = scala.compiletime.uninitialized
+  private var message: Error              = scala.compiletime.uninitialized
+  private var encoded: EntityToDecode[IO] = scala.compiletime.uninitialized
+
+  private val encodeOptions =
+    EncodeOptions(StandardCharsets.UTF_8, ContentCoding.identity)
+
+  @Setup
+  def setup(): Unit = {
+    codec = JsonSerdesBuilder[IO]().build.codec
+    message = Error(
+      code = Code.Internal,
+      message = Some("A representative Connect error response"),
+      details = Vector.tabulate(detailsCount) { index =>
+        ErrorDetailsAny(
+          `type` = s"type.googleapis.com/benchmark.Payload$index",
+          value = ByteString.copyFrom(Array.tabulate(128)(i => (index + i).toByte)),
+        )
+      },
+    )
+
+    val bytes = serializeBody()
+    encoded = EntityToDecode(Stream.emits(bytes), new Metadata())
+  }
+
+  @Benchmark
+  def parseBody(): Error =
+    codec.decode[Error](encoded).compile.lastOrError.unsafeRunSync()
+
+  @Benchmark
+  def serializeBody(): Array[Byte] =
+    codec
+      .encode(Stream.emit(message), encodeOptions)
+      .body
+      .compile
+      .to(Array)
+      .unsafeRunSync()
+}

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,14 @@ lazy val conformance = project
     ),
   )
 
+lazy val benchmarks = project
+  .dependsOn(core)
+  .enablePlugins(JmhPlugin)
+  .settings(
+    name := "connect-rpc-scala-benchmarks",
+    noPublish,
+  )
+
 lazy val examples = project.in(file("examples"))
   .aggregate(
     example_connectrpc_grpc_servers,
@@ -168,6 +176,7 @@ lazy val root = (project in file("."))
     http4s,
     netty,
     conformance,
+    benchmarks,
     examples,
   )
   .settings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,6 +4,7 @@ addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")
 addSbtPlugin("com.thesamet"   % "sbt-protoc"          % "1.0.8")
 addSbtPlugin("org.typelevel"  % "sbt-fs2-grpc"        % "3.1.2")
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"        % "2.6.2")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh"          % "0.4.8")
 
 libraryDependencies += "com.thesamet.scalapb"          %% "compilerplugin"   % "0.11.20"
 libraryDependencies += "com.thesamet.scalapb.zio-grpc" %% "zio-grpc-codegen" % "0.6.3"


### PR DESCRIPTION
## Summary

- add a non-published `benchmarks` module powered by JMH
- benchmark end-to-end unary JSON body parsing and serialization through `JsonMessageCodec`
- cover small, medium, and large representative Connect error bodies using 1, 10, and 100 details
- document full and quick local benchmark commands and comparison guidance

## Why

JSON parsing and serialization are performance-sensitive request paths, but the repository did not have repeatable
microbenchmarks for evaluating implementation changes. Keeping the benchmark module independent from the JSON backend
makes it suitable for direct A/B comparisons such as json4s versus Circe.

## Validation

- `sbt scalafmtCheckAll test` — 31 tests passed
- `sbt benchmarks/Jmh/compile` — JMH discovered and generated both benchmarks
- full JMH baseline — 2 forks, 5 warmup iterations, 10 measurement iterations, 1 thread, GC profiler
